### PR TITLE
Depend on working version of youtube-dl.

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "rimraf": "^2.5.2",
     "which": "^1.2.4",
     "yargs": "^4.3.2",
-    "youtube-dl": "~1.10.5"
+    "youtube-dl": "~1.11.1"
   },
   "engines": {
     "node": ">= 0.8.x"


### PR DESCRIPTION
Trying to use version 1.10.5 of youtube-dl yields in an ELIFECYCLE error.
Stepping to latest version makes problem go away. Not necessarily the most
elegant solution. Version selection for dependencies should probably be done
more carefully, but I'm not prepared to fully step down into that swamp.

Fixes issue #77.
